### PR TITLE
centered the thank you header on mobile

### DIFF
--- a/src/components/home/Thanks.css
+++ b/src/components/home/Thanks.css
@@ -27,7 +27,7 @@
     .thanks {
         font-size: 3em;
         font-family: 'Questrial', sans-serif;
-        text-align: left;
+        text-align: center;
     }
 
     .thanks-paragraph {


### PR DESCRIPTION
Git checkout lr-center-mobile-thanks

On mobile, the thank you header should be centered.